### PR TITLE
Fix for hidden/disabled MFA type selector

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -81,9 +81,10 @@ def get_web_driver(email, password, headless=False, mfa_method=None,
                 driver.find_element_by_id('ius-mfa-options-form')
                 try:
                     mfa_method_option = driver.find_element_by_id('ius-mfa-option-{}'.format(mfa_method))
-                    mfa_method_option.click()
-                    mfa_method_submit = driver.find_element_by_id("ius-mfa-options-submit-btn")
-                    mfa_method_submit.click()
+                    if mfa_method_option.is_displayed():
+                        mfa_method_option.click()
+                        mfa_method_submit = driver.find_element_by_id("ius-mfa-options-submit-btn")
+                        mfa_method_submit.click()
 
                     mfa_code = (mfa_input_callback or input)("Please enter your 6-digit MFA code: ")
                     mfa_code_input = driver.find_element_by_id("ius-mfa-confirm-code")


### PR DESCRIPTION
My account doesn't seem to prompt for which type of MFA to use so I wrapped that part in an `if`-block that skips those steps of the flow if the relevant element isn't visible.